### PR TITLE
YoutubeApiClientとSlackApiClientの修正

### DIFF
--- a/src/main/java/com/example/demo/DemoApplication.java
+++ b/src/main/java/com/example/demo/DemoApplication.java
@@ -1,17 +1,19 @@
 package com.example.demo;
 
+import java.util.List;
+
 public class DemoApplication {
     public static void main(String[] args) {
         int maxResult = 5; //Youtubeに返事した人気動画の数です。デフォルトで5にしておきます。
 
-        String[] videos = YoutubeApiClient.getVideos(args[1], maxResult, "JP");
+        List<String> videos = YoutubeApiClient.getVideos(args[1], maxResult, "JP");
 
         SlackApiClient slackApiClient = new SlackApiClient();
 
         String incomeWebhookUrl = args[0];
         String text = "今日のHOT動画は\n";
         for (int i = 0; i < maxResult; i++) {
-            text += videos[i];
+            text += videos.get(i) + "\n";
         }
 
         System.out.println(slackApiClient.postMessage(text, incomeWebhookUrl));

--- a/src/main/java/com/example/demo/DemoApplication.java
+++ b/src/main/java/com/example/demo/DemoApplication.java
@@ -1,35 +1,17 @@
 package com.example.demo;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import java.io.*;
-
 public class DemoApplication {
     public static void main(String[] args) {
         int maxResult = 5; //Youtubeに返事した人気動画の数です。デフォルトで5にしておきます。
 
-        String json = "";
-
-        YoutubeApiJson youtubeApiJson = null;
-        try {
-            json = YoutubeApiClient.getVideos(args[1], maxResult, "JP");
-
-            ObjectMapper mapper = new ObjectMapper();
-            youtubeApiJson = mapper.readValue(json, YoutubeApiJson.class);
-
-            System.out.println(youtubeApiJson.toString());
-        } catch (JsonProcessingException e) {
-            e.printStackTrace();
-            throw new UncheckedIOException(e);
-        }
+        String[] videos = YoutubeApiClient.getVideos(args[1], maxResult, "JP");
 
         SlackApiClient slackApiClient = new SlackApiClient();
 
         String incomeWebhookUrl = args[0];
-        json = "{\"text\":\"今日のＨＯＴ動画は\n";
+        String json = "{\"text\":\"今日のＨＯＴ動画は\n";
         for (int i = 0; i < maxResult; i++) {
-            json += "https://youtube.com/watch?v=" + youtubeApiJson.getItems()[i].getId() + "\n";
+            json += videos[i];
         }
         json += "\"}";
 

--- a/src/main/java/com/example/demo/DemoApplication.java
+++ b/src/main/java/com/example/demo/DemoApplication.java
@@ -9,13 +9,11 @@ public class DemoApplication {
         SlackApiClient slackApiClient = new SlackApiClient();
 
         String incomeWebhookUrl = args[0];
-        String json = "{\"text\":\"今日のＨＯＴ動画は\n";
+        String text = "今日のHOT動画は\n";
         for (int i = 0; i < maxResult; i++) {
-            json += videos[i];
+            text += videos[i];
         }
-        json += "\"}";
 
-        System.out.println(incomeWebhookUrl + '\n' + json);
-        System.out.println(slackApiClient.postMessage(json, incomeWebhookUrl));
+        System.out.println(slackApiClient.postMessage(text, incomeWebhookUrl));
     }
 }

--- a/src/main/java/com/example/demo/DemoApplication.java
+++ b/src/main/java/com/example/demo/DemoApplication.java
@@ -11,10 +11,10 @@ public class DemoApplication {
         SlackApiClient slackApiClient = new SlackApiClient();
 
         String incomeWebhookUrl = args[0];
-        String text = "今日のHOT動画は\n";
-        for (int i = 0; i < maxResult; i++) {
-            text += videos.get(i) + "\n";
-        }
+        String text = videos.stream().reduce(
+                "今日のHOT動画は\n", (String joined, String element) -> {
+                    return joined + element + "\n";
+                });
 
         System.out.println(slackApiClient.postMessage(text, incomeWebhookUrl));
     }

--- a/src/main/java/com/example/demo/SlackApiClient.java
+++ b/src/main/java/com/example/demo/SlackApiClient.java
@@ -5,7 +5,7 @@ import java.io.*;
 import java.net.URL;
 
 public class SlackApiClient {
-    public String postMessage(String json, String path) {
+    public String postMessage(String text, String path) {
         HttpsURLConnection uc;
         try {
             URL url = new URL(path);
@@ -20,6 +20,7 @@ public class SlackApiClient {
 
         try (OutputStreamWriter out = new OutputStreamWriter(
                 new BufferedOutputStream(uc.getOutputStream()))) {
+            String json = "{\"text\":\"" + text + "\"}";
             out.write(json);
         } catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/src/main/java/com/example/demo/YoutubeApiClient.java
+++ b/src/main/java/com/example/demo/YoutubeApiClient.java
@@ -1,5 +1,7 @@
 package com.example.demo;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import javax.net.ssl.HttpsURLConnection;
 import java.io.*;
 import java.net.MalformedURLException;
@@ -8,7 +10,7 @@ import java.net.URL;
 public class YoutubeApiClient {
 
     private static final String YOUTUBE_API_URL = "https://www.googleapis.com/youtube/v3/";
-    public static String getVideos (String key, int maxResult, String regionCode) {
+    public static String[] getVideos (String key, int maxResult, String regionCode) {
         URL url = null;
         String param = "videos?part=id" +
                 "&key=" + key +
@@ -41,7 +43,18 @@ public class YoutubeApiClient {
                 line = in.readLine();
             }
             uc.disconnect();
-            return body;
+
+            ObjectMapper mapper = new ObjectMapper();
+            YoutubeApiJson youtubeApiJson = mapper.readValue(body, YoutubeApiJson.class);
+
+            String[] videos = new String[maxResult];
+            String youtubeUrl = "https://youtube.com/watch?v=";
+
+            for(int i = 0; i < maxResult; i++) {
+                videos[i] = youtubeUrl + youtubeApiJson.getItems()[i].getId() + "\n";
+            }
+
+            return videos;
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/src/main/java/com/example/demo/YoutubeApiClient.java
+++ b/src/main/java/com/example/demo/YoutubeApiClient.java
@@ -3,14 +3,19 @@ package com.example.demo;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import javax.net.ssl.HttpsURLConnection;
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.UncheckedIOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
 
 public class YoutubeApiClient {
 
     private static final String YOUTUBE_API_URL = "https://www.googleapis.com/youtube/v3/";
-    public static String[] getVideos (String key, int maxResult, String regionCode) {
+    public static List<String> getVideos (String key, int maxResult, String regionCode) {
         URL url = null;
         String param = "videos?part=id" +
                 "&key=" + key +
@@ -47,11 +52,11 @@ public class YoutubeApiClient {
             ObjectMapper mapper = new ObjectMapper();
             YoutubeApiJson youtubeApiJson = mapper.readValue(body, YoutubeApiJson.class);
 
-            String[] videos = new String[maxResult];
+            List<String> videos = new ArrayList<String>();
             String youtubeUrl = "https://youtube.com/watch?v=";
 
             for(int i = 0; i < maxResult; i++) {
-                videos[i] = youtubeUrl + youtubeApiJson.getItems()[i].getId() + "\n";
+                videos.add(youtubeUrl + youtubeApiJson.getItems()[i].getId());
             }
 
             return videos;

--- a/src/main/java/com/example/demo/YoutubeApiClient.java
+++ b/src/main/java/com/example/demo/YoutubeApiClient.java
@@ -9,8 +9,8 @@ import java.io.InputStreamReader;
 import java.io.UncheckedIOException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class YoutubeApiClient {
 
@@ -52,12 +52,9 @@ public class YoutubeApiClient {
             ObjectMapper mapper = new ObjectMapper();
             YoutubeApiJson youtubeApiJson = mapper.readValue(body, YoutubeApiJson.class);
 
-            List<String> videos = new ArrayList<String>();
             String youtubeUrl = "https://youtube.com/watch?v=";
 
-            for(int i = 0; i < maxResult; i++) {
-                videos.add(youtubeUrl + youtubeApiJson.getItems()[i].getId());
-            }
+            List<String> videos = youtubeApiJson.getItems().stream().map(item -> youtubeUrl + item.getId()).collect(Collectors.toList());
 
             return videos;
         } catch (IOException e) {

--- a/src/main/java/com/example/demo/YoutubeApiJson.java
+++ b/src/main/java/com/example/demo/YoutubeApiJson.java
@@ -1,5 +1,7 @@
 package com.example.demo;
 
+import java.util.List;
+
 public class YoutubeApiJson {
     public class PageInfo {
         private int totalResults;
@@ -26,7 +28,7 @@ public class YoutubeApiJson {
     private String nextPageToken;
     private String prevPageToken;
     private PageInfo pageInfo;
-    private YoutubeVideoJson[] items;
+    private List<YoutubeVideoJson> items;
 
     public void setKind (String kind) {
         this.kind = kind;
@@ -48,7 +50,7 @@ public class YoutubeApiJson {
         this.pageInfo = pageInfo;
     }
 
-    public void setItems(YoutubeVideoJson[] items) {
+    public void setItems(List<YoutubeVideoJson> items) {
         this.items = items;
     }
 
@@ -71,7 +73,7 @@ public class YoutubeApiJson {
         return pageInfo;
     }
 
-    public YoutubeVideoJson[] getItems() {
+    public List<YoutubeVideoJson> getItems() {
         return items;
     }
 


### PR DESCRIPTION
1. YoutubeApiClientのgetVideos()メソッドからjsonではなく、動画のurlをもらえた。
2. SlackApiClientのpostMessage()メソッドに送りたいのメッセージテキストをパレメータとして送ればユーザーに正しい結果を送れる。jsonを作る必要がない。